### PR TITLE
Feature/enable deferred user verification

### DIFF
--- a/app/org/zalando/hutmann/authentication/Filters.scala
+++ b/app/org/zalando/hutmann/authentication/Filters.scala
@@ -1,0 +1,71 @@
+package org.zalando.hutmann.authentication
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+/**
+  * Contains filters for the authentication that can be used to filter requests
+  */
+object Filters {
+  /**
+    * Checks if a user has all the given scopes (AND-combination of all scopes)
+    *
+    * @param scopes All mandatory scopes that are needed on a user to pass this check.
+    */
+  def allScopes(scopes: String*): User => Future[Boolean] = { user: User =>
+    Future.successful(scopes.forall(user.scope.keySet.contains))
+  }
+
+  /**Checks if a user has the given scope, or not*/
+  def scope(scope: String): User => Future[Boolean] = { user: User =>
+    Future.successful(user.scope.keySet.contains(scope))
+  }
+
+  /**
+    * Checks if a user has at least one of the given scopes.
+    * Use case: {{{scope("myscope.all") || scope("myscope.write") == atLeastOneScope("myscope.all", "myscope.write"}}}
+    */
+  def atLeastOneScope(scopes: String*): User => Future[Boolean] = { user: User =>
+    Future.successful(scopes.exists(user.scope.keySet.contains))
+  }
+
+  /**Checks whether the user has a uid, or not*/
+  val hasUid: User => Future[Boolean] = { user: User =>
+    Future.successful(user.uid.isDefined)
+  }
+
+  /**Checks whether the user comes from a given realm, or not*/
+  def fromRealm(realm: String): User => Future[Boolean] = { user: User =>
+    Future.successful(user.realm == realm)
+  }
+
+  /**Checks whether the given token is a bearer token*/
+  val bearerToken: User => Future[Boolean] = { user: User =>
+    Future.successful(user.tokenType == "Bearer")
+  }
+
+  /**
+    * Implicit conversion that makes it easy to combine other filters in a readable fashion. Enables the following syntax:
+    * {{{scopes("myscope.all") || kohleTeamMember}}}, which allows access to users with the given scopes, or members of team kohle although
+    * they do not have the given scopes.
+    *
+    * {{{scopes("myscope.all")}}}
+    */
+  implicit class FilterCompositor(val filter: User => Future[Boolean]) extends AnyVal {
+    //scalastyle:off method.name
+    /**Combines two filters with a logical OR. Uses short-cuts if possible, therefore only calls the second service if it is actually needed*/
+    def ||(otherFilter: User => Future[Boolean])(implicit ec: ExecutionContext): User => Future[Boolean] = { user: User =>
+      filter(user).flatMap{
+        case true  => Future.successful(true)
+        case false => otherFilter(user)
+      }
+    }
+    /**Combines two filters with a logical AND. Uses short-cuts if possible, therefore only calls the second service if it is actually needed*/
+    def &&(otherFilter: User => Future[Boolean])(implicit ec: ExecutionContext): User => Future[Boolean] = { user: User =>
+      filter(user).flatMap{
+        case true  => otherFilter(user)
+        case false => Future.successful(false)
+      }
+    }
+    //scalastyle:on method.name
+  }
+}

--- a/app/org/zalando/hutmann/authentication/Filters.scala
+++ b/app/org/zalando/hutmann/authentication/Filters.scala
@@ -38,6 +38,11 @@ object Filters {
     Future.successful(user.realm == realm)
   }
 
+  /**Checks whether the caller comes from realm "/employees" and has a uid*/
+  def isEmployee(implicit ec: ExecutionContext): User => Future[Boolean] = hasUid && fromRealm("/employees")
+  /**Checks whether the caller comes from the realm "/services" and has a uid*/
+  def isService(implicit ec: ExecutionContext): User => Future[Boolean] = hasUid && fromRealm("/services")
+
   /**Checks whether the given token is a bearer token*/
   val bearerToken: User => Future[Boolean] = { user: User =>
     Future.successful(user.tokenType == "Bearer")

--- a/app/org/zalando/hutmann/authentication/Filters.scala
+++ b/app/org/zalando/hutmann/authentication/Filters.scala
@@ -71,6 +71,10 @@ object Filters {
         case false => Future.successful(false)
       }
     }
+    /**Negation of a predicate*/
+    def unary_!(implicit ec: ExecutionContext): User => Future[Boolean] = { user: User =>
+      filter(user).map(!_)
+    }
     //scalastyle:on method.name
   }
 }

--- a/app/org/zalando/hutmann/authentication/OAuth2Action.scala
+++ b/app/org/zalando/hutmann/authentication/OAuth2Action.scala
@@ -36,7 +36,7 @@ class OAuth2Action(
   val queryParamTokenPattern = Patterns.queryParamTokenPattern
   val headerTokenPattern = Patterns.headerTokenPattern
 
-  val logger = Logger("org.zalando.hutmann.oauth2")
+  val logger = Logger( /*"org.zalando.hutmann.oauth2"*/ )
 
   def validateToken(token: String)(implicit context: Context): Future[Either[OAuth2Error, User]] = {
     val request: WSRequest = WS.url(url)

--- a/app/org/zalando/hutmann/filters/FlowIdFilter.scala
+++ b/app/org/zalando/hutmann/filters/FlowIdFilter.scala
@@ -2,7 +2,7 @@ package org.zalando.hutmann.filters
 
 import scala.concurrent.Future
 import scala.language.implicitConversions
-import play.api.mvc.{ Result, RequestHeader, Filter }
+import play.api.mvc.{ Filter, RequestHeader, Result }
 import play.api.mvc.Results.BadRequest
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import java.util.{ Base64, UUID }

--- a/app/org/zalando/hutmann/filters/LoggingFilter.scala
+++ b/app/org/zalando/hutmann/filters/LoggingFilter.scala
@@ -16,6 +16,7 @@ final class LoggingFilter(logHeaders: Boolean)(implicit ec: ExecutionContext) ex
   def this()(implicit ec: ExecutionContext) = this(logHeaders = false)
 
   val accessToken = "access_token"
+  val logger = Logger("org.zalando.hutmann.filters")
 
   /**
     * Function that deletes some values from the given sequence of key/value pairs, depending on the key.
@@ -70,7 +71,7 @@ final class LoggingFilter(logHeaders: Boolean)(implicit ec: ExecutionContext) ex
       } else {
         headLine
       }
-      Logger.info(logLine)
+      logger.info(logLine)
 
       result
     }

--- a/app/org/zalando/hutmann/filters/LoggingFilter.scala
+++ b/app/org/zalando/hutmann/filters/LoggingFilter.scala
@@ -55,7 +55,7 @@ final class LoggingFilter(logHeaders: Boolean)(implicit ec: ExecutionContext) ex
       //this is the line that will get printed anyway, no matter what
       val headLine = result.header.headers.get("x-flow-id") match {
         case Some(flowId) =>
-          s"$flowId - ${rh.method} ${rh.path}$queryString returned ${result.header.status}$eTag, took ${requestTime}ms"
+          s"${rh.method} ${rh.path}$queryString returned ${result.header.status}$eTag, took ${requestTime}ms ($flowId)"
         case None =>
           s"${rh.method} ${rh.path}$queryString returned ${result.header.status}$eTag, took ${requestTime}ms"
       }

--- a/app/org/zalando/hutmann/logging/Logger.scala
+++ b/app/org/zalando/hutmann/logging/Logger.scala
@@ -66,6 +66,11 @@ class Logger(name: String) {
   * If you really do not want to have a context, you can supply the case object
   * {{{NoContextAvailable}}} - either explicitly, or as an implicit value.
   */
-object Logger extends Logger("default") {
+object Logger extends Logger("application") {
   def apply(name: String): Logger = new Logger(name)
+  def apply()(implicit name: sourcecode.Name, fullname: sourcecode.FullName): Logger = {
+    //use the enclosing class name as logger name. To get it, extract the full name and remove the length of the name plus the extra dot.
+    val loggerName = fullname.value.dropRight(name.value.length + 1)
+    new Logger(loggerName)
+  }
 }

--- a/app/org/zalando/hutmann/logging/Logger.scala
+++ b/app/org/zalando/hutmann/logging/Logger.scala
@@ -2,7 +2,9 @@ package org.zalando.hutmann.logging
 
 import java.time.{ Duration, ZonedDateTime }
 
-trait Logger {
+class Logger(name: String) {
+  val logger = play.api.Logger(name)
+
   protected def createLogString(message: => String, context: Context, file: sourcecode.File, line: sourcecode.Line): String = {
     val codeContext = s"${file.value.substring(file.value.lastIndexOf("/") + 1)}:${line.value}"
     val flowDuration = Duration.between(context.contextInitializationTime, ZonedDateTime.now())
@@ -18,36 +20,36 @@ trait Logger {
     s"$message - $contextInfo"
   }
 
-  def isTraceEnabled: Boolean = play.api.Logger.isTraceEnabled
-  def isDebugEnabled: Boolean = play.api.Logger.isDebugEnabled
-  def isInfoEnabled: Boolean = play.api.Logger.isInfoEnabled
-  def isWarnEnabled: Boolean = play.api.Logger.isWarnEnabled
-  def isErrorEnabled: Boolean = play.api.Logger.isErrorEnabled
+  def isTraceEnabled: Boolean = logger.isTraceEnabled
+  def isDebugEnabled: Boolean = logger.isDebugEnabled
+  def isInfoEnabled: Boolean = logger.isInfoEnabled
+  def isWarnEnabled: Boolean = logger.isWarnEnabled
+  def isErrorEnabled: Boolean = logger.isErrorEnabled
 
   def trace(message: => String)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.trace(createLogString(message, context, file, line))
+    logger.trace(createLogString(message, context, file, line))
   def trace(message: => String, error: => Throwable)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.trace(createLogString(message, context, file, line), error)
+    logger.trace(createLogString(message, context, file, line), error)
 
   def debug(message: => String)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.debug(createLogString(message, context, file, line))
+    logger.debug(createLogString(message, context, file, line))
   def debug(message: => String, error: => Throwable)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.debug(createLogString(message, context, file, line), error)
+    logger.debug(createLogString(message, context, file, line), error)
 
   def info(message: => String)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.info(createLogString(message, context, file, line))
+    logger.info(createLogString(message, context, file, line))
   def info(message: => String, error: => Throwable)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.info(createLogString(message, context, file, line), error)
+    logger.info(createLogString(message, context, file, line), error)
 
   def warn(message: => String)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.warn(createLogString(message, context, file, line))
+    logger.warn(createLogString(message, context, file, line))
   def warn(message: => String, error: => Throwable)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.warn(createLogString(message, context, file, line), error)
+    logger.warn(createLogString(message, context, file, line), error)
 
   def error(message: => String)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.error(createLogString(message, context, file, line))
+    logger.error(createLogString(message, context, file, line))
   def error(message: => String, error: => Throwable)(implicit context: Context, file: sourcecode.File, line: sourcecode.Line): Unit =
-    play.api.Logger.error(createLogString(message, context, file, line), error)
+    logger.error(createLogString(message, context, file, line), error)
 }
 
 /**
@@ -64,4 +66,6 @@ trait Logger {
   * If you really do not want to have a context, you can supply the case object
   * {{{NoContextAvailable}}} - either explicitly, or as an implicit value.
   */
-object Logger extends Logger
+object Logger extends Logger("default") {
+  def apply(name: String): Logger = new Logger(name)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,36 @@ libraryDependencies ++= Seq(
 maintainer := "team-kohle@zalando.de"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
+//pom extra info
+publishMavenStyle := true
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+
+publishArtifact in Test := false
+
+pomExtra := (
+  <scm>
+    <url>git@github.com:zalando-incubator/hutmann.git</url>
+    <developerConnection>scm:git:git@github.com:zalando-incubator/hutmann.git</developerConnection>
+    <connection>scm:git:https://github.com/zalando-incubator/hutmann.git</connection>
+  </scm>
+    <developers>
+      <developer>
+        <name>Lena Brueder</name>
+        <email>lena.brueder@zalando.de</email>
+        <url>https://github.com/zalando</url>
+      </developer>
+    </developers>)
+
+homepage := Some(url("https://github.com/zalando-incubator/hutmann"))
+
+//settings to compile readme
 tutSettings
 tutSourceDirectory := baseDirectory.value / "tut"
 tutTargetDirectory := baseDirectory.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,7 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
 
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.4")
+
+//for publishing
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/test/org/zalando/hutmann/authentication/FiltersSpec.scala
+++ b/test/org/zalando/hutmann/authentication/FiltersSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import org.zalando.hutmann.spec.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class FiltersSpec extends UnitSpec {
   def userWithScopes(scopes: String*) = User(UUID.randomUUID().toString, Map(scopes.map(_ -> None): _*), "test", "Bearer", 3600, Some("testuser"))
@@ -115,5 +116,12 @@ class FiltersSpec extends UnitSpec {
     andFilter(userWithScopes("myscope.read")).futureValue shouldBe true
     andFilter(userWithScopes("myscope.write")).futureValue shouldBe true
     andFilter(userWithScopes("myscope.read", "myscope.write")).futureValue shouldBe true
+  }
+  it should "be able to negate with !" in {
+    import Filters._
+    val notTrueFilter = !{ user: User => Future.successful(true) }
+    val notFalseFilter = !{ user: User => Future.successful(false) }
+    notTrueFilter(userWithScopes()).futureValue shouldBe false
+    notFalseFilter(userWithScopes()).futureValue shouldBe true
   }
 }

--- a/test/org/zalando/hutmann/authentication/FiltersSpec.scala
+++ b/test/org/zalando/hutmann/authentication/FiltersSpec.scala
@@ -1,0 +1,93 @@
+package org.zalando.hutmann.authentication
+
+import java.util.UUID
+
+import org.zalando.hutmann.spec.UnitSpec
+
+class FiltersSpec extends UnitSpec {
+  def userWithScopes(scopes: String*) = User(UUID.randomUUID().toString, Map(scopes.map(_ -> None): _*), "test", "Bearer", 3600, Some("testuser"))
+
+  "Filters.scope" should "succeed if that scope exists for the user" in {
+    val filter = Filters.scope("myscope.all")
+    filter(userWithScopes("myscope.all")).futureValue shouldBe true
+  }
+  it should "fail if the scope does not exist for the user" in {
+    val filter = Filters.scope("myscope.write")
+    filter(userWithScopes("myscope.read")).futureValue shouldBe false
+  }
+
+  "Filters.allScopes" should "succeed if the user has all the scopes" in {
+    val filter = Filters.allScopes("myscope.write", "myscope.read")
+    filter(userWithScopes("myscope.write", "myscope.read")).futureValue shouldBe true
+    //ordering should not matter
+    filter(userWithScopes("myscope.read", "myscope.write")).futureValue shouldBe true
+  }
+  it should "fail if the user misses one scope" in {
+    val filter = Filters.allScopes("myscope.write", "myscope.read")
+    filter(userWithScopes("myscope.write")).futureValue shouldBe false
+    filter(userWithScopes("myscope.read")).futureValue shouldBe false
+  }
+  it should "fail if the user misses all scopes" in {
+    val filter = Filters.allScopes("myscope.write", "myscope.read")
+    filter(userWithScopes()).futureValue shouldBe false
+  }
+
+  "Filters.atLeastOneScope" should "succeed if all scopes are present" in {
+    val filter = Filters.atLeastOneScope("myscope.write", "myscope.read")
+    filter(userWithScopes("myscope.write", "myscope.read")).futureValue shouldBe true
+    //ordering should not matter
+    filter(userWithScopes("myscope.read", "myscope.write")).futureValue shouldBe true
+  }
+  it should "succeed if just one of the scopes is given" in {
+    val filter = Filters.atLeastOneScope("myscope.write", "myscope.read")
+    filter(userWithScopes("myscope.write")).futureValue shouldBe true
+    //ordering should not matter
+    filter(userWithScopes("myscope.read")).futureValue shouldBe true
+  }
+  it should "fail if none of the scopes is given" in {
+    val filter = Filters.allScopes("myscope.write", "myscope.read")
+    filter(userWithScopes()).futureValue shouldBe false
+  }
+
+  "Filters.hasUid" should "succeed for users with a uid scope" in {
+    Filters.hasUid(userWithScopes()).futureValue shouldBe true
+  }
+  it should "fail for users without a uid scope" in {
+    Filters.hasUid(userWithScopes().copy(uid = None)).futureValue shouldBe false
+  }
+
+  "Filters.fromRealm" should "succeed for users from the given realm" in {
+    val filter = Filters.fromRealm("test")
+    filter(userWithScopes()).futureValue shouldBe true
+  }
+  it should "fail for users from another realm" in {
+    val filter = Filters.fromRealm("anotherrealm")
+    filter(userWithScopes()).futureValue shouldBe false
+  }
+
+  "Filters.bearerToken" should "succeed for bearer tokens" in {
+    Filters.bearerToken(userWithScopes()).futureValue shouldBe true
+  }
+  it should "fail for other tokens" in {
+    Filters.bearerToken(userWithScopes().copy(tokenType = "Other")).futureValue shouldBe false
+  }
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  "Filters" should "be composable with &&" in {
+    import Filters._
+    val andFilter = scope("myscope.read") && scope("myscope.write")
+    andFilter(userWithScopes()).futureValue shouldBe false
+    andFilter(userWithScopes("myscope.read")).futureValue shouldBe false
+    andFilter(userWithScopes("myscope.write")).futureValue shouldBe false
+    andFilter(userWithScopes("myscope.read", "myscope.write")).futureValue shouldBe true
+
+  }
+  it should "be composable with ||" in {
+    import Filters._
+    val andFilter = scope("myscope.read") || scope("myscope.write")
+    andFilter(userWithScopes()).futureValue shouldBe false
+    andFilter(userWithScopes("myscope.read")).futureValue shouldBe true
+    andFilter(userWithScopes("myscope.write")).futureValue shouldBe true
+    andFilter(userWithScopes("myscope.read", "myscope.write")).futureValue shouldBe true
+  }
+}

--- a/test/org/zalando/hutmann/authentication/UserSpec.scala
+++ b/test/org/zalando/hutmann/authentication/UserSpec.scala
@@ -2,8 +2,8 @@ package org.zalando.hutmann.authentication
 
 import java.util.UUID
 
-import org.zalando.hutmann.UnitSpec
 import User.app2AppUserReader
+import org.zalando.hutmann.spec.UnitSpec
 import play.api.libs.json.Json
 
 import scala.util.Random

--- a/test/org/zalando/hutmann/filters/FlowIdFilterTest.scala
+++ b/test/org/zalando/hutmann/filters/FlowIdFilterTest.scala
@@ -1,8 +1,7 @@
 package org.zalando.hutmann.filters
 
 import org.scalatestplus.play._
-import org.zalando.hutmann.{ PlayUnitSpec, UnitSpec }
-import org.zalando.hutmann.filters.{ Create, FlowIdFilter, Strict }
+import org.zalando.hutmann.spec.{ PlayUnitSpec, UnitSpec }
 import play.api.http.Status
 import play.api.mvc._
 import play.api.test.Helpers._

--- a/test/org/zalando/hutmann/logging/LoggerDemo.scala
+++ b/test/org/zalando/hutmann/logging/LoggerDemo.scala
@@ -1,7 +1,7 @@
 package org.zalando.hutmann.logging
 
-import org.zalando.hutmann.UnitSpec
 import org.zalando.hutmann.authentication.User
+import org.zalando.hutmann.spec.UnitSpec
 import play.api.test.FakeRequest
 
 import scala.util.Random

--- a/test/org/zalando/hutmann/logging/LoggerDemo.scala
+++ b/test/org/zalando/hutmann/logging/LoggerDemo.scala
@@ -7,12 +7,14 @@ import play.api.test.FakeRequest
 import scala.util.Random
 
 class LoggerDemo extends UnitSpec {
+  val logger = Logger()
+
   def logStatements(implicit context: Context): Unit = {
-    Logger.trace("This is a test")
-    Logger.debug("This is a test")
-    Logger.info("This is a test")
-    Logger.warn("This is a test")
-    Logger.error("This is a test")
+    logger.trace("This is a test")
+    logger.debug("This is a test")
+    logger.info("This is a test")
+    logger.warn("This is a test")
+    logger.error("This is a test")
   }
 
   "The logger" should "be demonstrated without a context" in {

--- a/test/org/zalando/hutmann/spec/PlayUnitSpec.scala
+++ b/test/org/zalando/hutmann/spec/PlayUnitSpec.scala
@@ -1,4 +1,4 @@
-package org.zalando.hutmann
+package org.zalando.hutmann.spec
 
 import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.ScalaFutures

--- a/test/org/zalando/hutmann/spec/UnitSpec.scala
+++ b/test/org/zalando/hutmann/spec/UnitSpec.scala
@@ -1,4 +1,4 @@
-package org.zalando.hutmann
+package org.zalando.hutmann.spec
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{ Millis, Seconds, Span }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.1-SNAPSHOT"
+version := "0.2-SNAPSHOT"


### PR DESCRIPTION
Added possibility to have deferred user verification filters. The use case is as follows: You cannot in every single case make sure you do not need external information to decide if a user should get authorized, or not. Sometimes additional information is needed (e.g. allow access for all users of a specific team, but getting to know if the person is on a specific team needs another service call).

To make this possible, the user verification function now takes a `User`, and returns a `Future[Boolean]` instead of a `Boolean`. You are able to lazily combine predicates using the implicit class `FilterCompositor`. See `FiltersSpec` for information on how to use them.