### PR TITLE
Fixed bug related to issue 8, request body is parsed before authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ import scala.concurrent.ExecutionContext.Implicits.global
   }
 ```
 
+or use(recommended) [EssentialAction](https://www.playframework.com/documentation/2.5.x/ScalaEssentialAction) to authenticate request first and then proceed with everything else like request body parsing etc.
+side effects of not using EssentialAction is explained in detail in this [issue](https://github.com/zalando-incubator/hutmann/issues/8)
+
+```scala
+ import scala.concurrent.ExecutionContext
+ import play.api.libs.ws.WSClient
+ import play.api.Configuration
+ import scala.util.Future
+ 
+ //these come from the application normally
+ implicit val ws: WSClient = null
+ implicit val config: Configuration = null
+ import scala.concurrent.ExecutionContext.Implicits.global
+ 
+ def heartbeat = OAuth2Action()(implicitly[ExecutionContext], implicitly[WSClient], implicitly[Configuration]).essentialAction(parse.default) { 
+     Future.successful(Ok("<3"))
+ }
+```
+
 and it automatically makes sure that requests to that route have a valid authentication token - although most probably,
 you won't make your heartbeat endpoint secured.
 

--- a/app/org/zalando/hutmann/authentication/OAuth2Action.scala
+++ b/app/org/zalando/hutmann/authentication/OAuth2Action.scala
@@ -2,16 +2,22 @@ package org.zalando.hutmann.authentication
 
 import java.util.concurrent.TimeoutException
 
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Flow
+import akka.util.ByteString
 import com.typesafe.config.Config
 import org.zalando.hutmann.logging.{ Context, Logger, RequestContext }
 import play.api.Configuration
 import play.api.http.{ HeaderNames, MimeTypes, Status }
+import play.api.libs.streams.Accumulator
 import play.api.libs.ws.{ WSClient, WSRequest }
 import play.api.mvc.Results._
 import play.api.mvc._
 
-import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
@@ -129,39 +135,63 @@ class OAuth2Action(
   /**
     * Add the authorization information to the request.
     */
-  def transform[A](request: Request[A]): Future[UserRequest[A]] = {
-    implicit val context: RequestContext = request
-    val tokenOpt: Option[String] = getToken(request)
+  def authenticate(requestHeader: RequestHeader): Future[Either[AuthorizationProblem, User]] = {
+    implicit val context: RequestContext = requestHeader
+    val tokenOpt: Option[String] = getToken(requestHeader)
     tokenOpt match {
       case Some(token) =>
         val futureToken = validateToken(token).recoverWith {
           case NonFatal(ex) =>
             logger.warn("Problem getting OAuth token, retrying...", ex)
             validateToken(token)
-        }.flatMap{
+        }.flatMap {
           case Left(TimeoutAuthError) =>
             logger.warn("Gateway timeout while getting OAuth token, retrying...")
             validateToken(token)
           case other => Future.successful(other)
         }
-        val futureUser = futureToken.flatMap(tokenResultScoring).recoverWith({
+        futureToken.flatMap(tokenResultScoring).recoverWith({
           case _: TimeoutException => Future.successful(Left(AuthorizationTimeout))
           case e                   => throw e
         })
-        futureUser.map(new UserRequest(_, request))
       case None =>
         logger.info("No authorization founder in 'Authorization' header or 'access_token' query parameter. Rejecting access.")
-        Future.successful(new UserRequest(Left(NoAuthorization), request))
+        Future.successful(Left(NoAuthorization))
     }
   }
 
   override def invokeBlock[A](request: Request[A], block: (UserRequest[A]) => Future[Result]): Future[Result] = {
-    transform(request).flatMap(userRequest =>
+    authenticate(request).flatMap { user =>
+      implicit val context: RequestContext = request
+      val userRequest = new UserRequest[A](user, request)
       if (autoReject) {
         autoRejectBehaviour(userRequest.user, block(userRequest))
       } else {
         block(userRequest)
-      }) recoverWith recoveryBehaviour(request)
+      }
+    } recoverWith recoveryBehaviour(request)
+  }
+
+  def essentialAction[A](bodyParser: BodyParser[A])(block: UserRequest[A] => Future[Result]): EssentialAction = {
+    implicit val actorSystem = ActorSystem("hutmann-actor-system")
+    implicit val materializer = ActorMaterializer(namePrefix = Some("hutmann-actor-materializer"))
+    EssentialAction { requestHeader =>
+      Accumulator.flatten[ByteString, Result] {
+        authenticate(requestHeader).map { user =>
+
+          lazy val accumulator = Action.async[A](bodyParser) { request =>
+            val userRequest = new UserRequest[A](user, request)(request)
+            block(userRequest)
+          }(requestHeader)
+
+          if (autoReject) {
+            autoRejectBehaviour(user, accumulator)
+          } else {
+            accumulator
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -181,6 +211,19 @@ class OAuth2Action(
       case Left(AuthorizationTimeout)       => Future.successful(GatewayTimeout)
     }
 
+  def autoRejectBehaviour[A](
+    userResult:  Either[AuthorizationProblem, User],
+    accumulator: => Accumulator[ByteString, Result]
+  ): Accumulator[ByteString, Result] = {
+
+    lazy val emptyFlow = Flow[ByteString]
+    userResult match {
+      case Right(user)                      => accumulator
+      case Left(InsufficientPermissions(_)) => emptyFlow ~>: Accumulator.done[Result](Forbidden)
+      case Left(NoAuthorization)            => emptyFlow ~>: Accumulator.done[Result](Unauthorized)
+      case Left(AuthorizationTimeout)       => emptyFlow ~>: Accumulator.done[Result](GatewayTimeout)
+    }
+  }
   /**
     * Function that describes how to behave when an exception is caught. This function may as well just re-throw the exception,
     * which forces Play to handle that problem. Default-Behaviour is to answer with 500 - internal server error, and log that exception

--- a/test/org/zalando/hutmann/authentication/Helper.scala
+++ b/test/org/zalando/hutmann/authentication/Helper.scala
@@ -1,0 +1,77 @@
+package org.zalando.hutmann.authentication
+
+import java.io.{ ByteArrayOutputStream, PrintWriter }
+
+import akka.NotUsed
+import akka.stream.scaladsl.{ Flow, Framing, Keep, Sink }
+import akka.util.ByteString
+import org.apache.http.entity.ContentType
+import org.apache.http.entity.mime.MultipartEntityBuilder
+import play.api.http.{ ContentTypeOf, Writeable }
+import play.api.libs.Files.TemporaryFile
+import play.api.libs.streams.Accumulator
+import play.api.mvc.MultipartFormData
+import play.api.mvc.MultipartFormData.FilePart
+import play.api.test.FakeRequest
+import play.core.parsers.Multipart.{ FileInfo, _ }
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class Helper(var mockDb: List[Int] = List()) {
+
+  val temporaryFile = TemporaryFile.apply(prefix = "test_file")
+
+  val printWriter = new PrintWriter(temporaryFile.file.getAbsolutePath)
+  (1 to 10).foreach(i => printWriter.write(s"$i\n"))
+  printWriter.close()
+
+  val multipartFormData = MultipartFormData[TemporaryFile](
+    dataParts = Map(),
+    files = Seq(FilePart[TemporaryFile]("file", temporaryFile.file.getName, None, temporaryFile)),
+    badParts = Nil
+  )
+
+  // A custom file part handler, which process the content of files in request body and store it into mockDb as well.
+  def handleFilePart: FilePartHandler[Int] = {
+    case FileInfo(partName, filename, contentType) =>
+      val byteStreamToLineFlow: Flow[ByteString, String, NotUsed] = Flow[ByteString].
+        via(Framing.delimiter(ByteString("\n"), 1000, allowTruncation = true)).map(_.utf8String)
+      val sink = byteStreamToLineFlow.toMat(Sink.fold(List[Int]()){ (r, c) =>
+        c.toInt +: r
+      })(Keep.right).mapMaterializedValue { resFut =>
+        resFut.map { res =>
+          mockDb = res
+          res.sum
+        }
+      }
+      val accumulator = Accumulator(sink)
+      accumulator.map(result => FilePart(partName, filename, contentType, result))
+  }
+
+  def multiPartFormDataWritable(request: FakeRequest[MultipartFormData[TemporaryFile]]): Writeable[MultipartFormData[TemporaryFile]] = {
+
+    val builder = MultipartEntityBuilder.create()
+
+    request.body.dataParts.foreach { case (k, vs) => builder.addTextBody(k, vs.mkString) }
+
+    // ContentType part is necessary here because it gets parsed as a DataPart otherwise.
+    request.body.files.foreach {
+      case f =>
+        builder.addBinaryBody("file", f.ref.file, ContentType.create(f.contentType.getOrElse("multipart/form-data"), "UTF-8"), f.filename)
+    }
+
+    val entity = builder.build()
+
+    implicit val contentType: ContentTypeOf[MultipartFormData[TemporaryFile]] = {
+      ContentTypeOf[MultipartFormData[TemporaryFile]](Some(entity.getContentType.getValue))
+    }
+
+    Writeable[MultipartFormData[TemporaryFile]] {
+      (mfd: MultipartFormData[TemporaryFile]) =>
+        val outputStream = new ByteArrayOutputStream()
+
+        entity.writeTo(outputStream)
+
+        ByteString(outputStream.toByteArray)
+    }
+  }
+}

--- a/test/org/zalando/hutmann/authentication/OAuth2ActionTest.scala
+++ b/test/org/zalando/hutmann/authentication/OAuth2ActionTest.scala
@@ -9,12 +9,15 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatestplus.play.OneAppPerSuite
 import org.zalando.hutmann.logging.Context
 import org.zalando.hutmann.spec.UnitSpec
+import play.api.mvc.MultipartFormData.FilePart
+import play.api.mvc.{ BodyParsers, Results }
 import play.api.test.{ FakeRequest, WsTestClient }
+import play.api.test.Helpers._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ ExecutionContext, Future }
 
-class OAuth2ActionTest extends UnitSpec with GeneratorDrivenPropertyChecks with OneAppPerSuite with WsTestClient {
+class OAuth2ActionTest extends UnitSpec with GeneratorDrivenPropertyChecks with OneAppPerSuite with WsTestClient with Results {
   implicit lazy val materializer: Materializer = app.materializer
   withClient {
     wsClient =>
@@ -39,6 +42,15 @@ class OAuth2ActionTest extends UnitSpec with GeneratorDrivenPropertyChecks with 
           ), implicitly[ExecutionContext], wsClient) {
             override def validateToken(token: String)(implicit context: Context): Future[Either[OAuth2Error, User]] = {
               Future.successful(user)
+            }
+          }
+
+        def oauth2withMockedServiceForEssentialAction(user: Either[AuthorizationProblem, User], accessToken: String, filter: User => Future[Boolean] = { user => Future.successful(true) }) =
+          new OAuth2Action(filter)(ConfigFactory.parseString(
+            "org.zalando.hutmann.authentication.oauth2: {\ntokenInfoUrl: \"https://info.services.auth.zalando.com/oauth2/tokeninfo\"\ntokenQueryParam: \"access_token\"}"
+          ), implicitly[ExecutionContext], wsClient) {
+            override def validateToken(token: String)(implicit context: Context): Future[Either[OAuth2Error, User]] = {
+              if (token == accessToken) Future.successful(user) else Future.successful(Left(NoAuthorization))
             }
           }
 
@@ -77,37 +89,37 @@ class OAuth2ActionTest extends UnitSpec with GeneratorDrivenPropertyChecks with 
 
       "OAuth2Action" should "accept a user with no filters" in {
         forAll { testUser: User =>
-          val result = oauth2withMockedService(Right(testUser)).transform(FakeRequest("GET", s"/?access_token=${testUser.accessToken}")).futureValue
-          result.user shouldBe Right(testUser)
+          val result = oauth2withMockedService(Right(testUser)).authenticate(FakeRequest("GET", s"/?access_token=${testUser.accessToken}")).futureValue
+          result shouldBe Right(testUser)
         }
       }
 
       it should "accept a user where the filter applies correctly" in {
         forAll { testUser: User =>
-          val result = oauth2withMockedService(Right(testUser), filter = Filters.scope("myscope")).transform(FakeRequest("GET", s"/?access_token=${testUser.accessToken}")).futureValue
-          result.user shouldBe Right(testUser)
+          val result = oauth2withMockedService(Right(testUser), filter = Filters.scope("myscope")).authenticate(FakeRequest("GET", s"/?access_token=${testUser.accessToken}")).futureValue
+          result shouldBe Right(testUser)
         }
       }
       it should "reject a user if the filter does not match" in {
         forAll { testUser: User =>
-          val result = oauth2withMockedService(Right(testUser), filter = Filters.scope("mywrongscope")).transform(FakeRequest("GET", s"/?access_token=${testUser.accessToken}")).futureValue
-          result.user shouldBe Left(InsufficientPermissions(testUser))
+          val result = oauth2withMockedService(Right(testUser), filter = Filters.scope("mywrongscope")).authenticate(FakeRequest("GET", s"/?access_token=${testUser.accessToken}")).futureValue
+          result shouldBe Left(InsufficientPermissions(testUser))
         }
       }
       it should "reject a user if the filter throws an exception" in {
         forAll { testUser: User =>
-          val result = oauth2withMockedService(Right(testUser), filter = { user => Future.failed(new IllegalArgumentException) }).transform(FakeRequest("GET", s"/?access_token=${testUser.accessToken}")).futureValue
-          result.user shouldBe Left(InsufficientPermissions(testUser))
+          val result = oauth2withMockedService(Right(testUser), filter = { user => Future.failed(new IllegalArgumentException) }).authenticate(FakeRequest("GET", s"/?access_token=${testUser.accessToken}")).futureValue
+          result shouldBe Left(InsufficientPermissions(testUser))
         }
       }
       it should "reject a user if the external system could not be reached" in {
         forAll(tokenGen) { token: String =>
-          val result = oauth2withMockedService(Left(AuthorizationTimeout)).transform(FakeRequest("GET", s"/?access_token=$token")).futureValue
-          result.user shouldBe Left(NoAuthorization)
+          val result = oauth2withMockedService(Left(AuthorizationTimeout)).authenticate(FakeRequest("GET", s"/?access_token=$token")).futureValue
+          result shouldBe Left(NoAuthorization)
         }
       }
 
-      "OAuth2.transform" should "retry cases where we get a gateway timeout from the oauth service" in new OAuth2Action()(ConfigFactory.parseString(
+      "OAuth2.authenticate" should "retry cases where we get a gateway timeout from the oauth service" in new OAuth2Action()(ConfigFactory.parseString(
         "org.zalando.hutmann.authentication.oauth2: {\ntokenInfoUrl: \"https://info.services.auth.zalando.com/oauth2/tokeninfo\"\ntokenQueryParam: \"access_token\"}"
       ), implicitly[ExecutionContext], wsClient) {
         @volatile var callCount = 0
@@ -123,11 +135,83 @@ class OAuth2ActionTest extends UnitSpec with GeneratorDrivenPropertyChecks with 
 
         forAll(tokenGen) { token: String =>
           callCount = 0
-          transform(FakeRequest("GET", s"/?access_token=$token")).futureValue.user
+          authenticate(FakeRequest("GET", s"/?access_token=$token")).futureValue
           withClue("tested if validateToken was called the correct number of times") {
             callCount shouldBe 2
           }
         }(generatorDrivenConfig.copy(minSuccessful = 5), Shrink.shrinkAny)
+      }
+
+      "OAuth2" should "parse request body before authenticating" in {
+        val helper = new Helper()
+        forAll { testUser: User =>
+          val fakeRequest = FakeRequest("GET", "/").
+            withHeaders("Authorization" -> s"Bearer ${UUID.randomUUID().toString}").
+            withBody(helper.multipartFormData)
+
+          implicit val writable = helper.multiPartFormDataWritable(fakeRequest)
+
+          val essentialAction = oauth2withMockedServiceForEssentialAction(Right(testUser), testUser.accessToken).
+            async(BodyParsers.parse.multipartFormData(helper.handleFilePart)){ request =>
+              request.body.file("file").fold(Future.successful(BadRequest("no file found"))){
+                case FilePart(_, _, _, result) =>
+                  Future.successful(Ok(result.toString))
+              }
+            }
+          val response = call(essentialAction, fakeRequest)
+          whenReady(response) { res =>
+            helper.mockDb should have size 10
+          }
+          status(response) shouldBe UNAUTHORIZED
+        }
+      }
+
+      "OAuth2.essentialAction" should "not parse request body before authenticating" in {
+        val helper = new Helper()
+        forAll { testUser: User =>
+          val fakeRequest = FakeRequest("GET", "/").
+            withHeaders("Authorization" -> s"Bearer ${UUID.randomUUID().toString}").
+            withBody(helper.multipartFormData)
+
+          implicit val writable = helper.multiPartFormDataWritable(fakeRequest)
+
+          val essentialAction = oauth2withMockedServiceForEssentialAction(Right(testUser), testUser.accessToken).
+            essentialAction(BodyParsers.parse.multipartFormData(helper.handleFilePart)){ request =>
+              request.body.file("file").fold(Future.successful(BadRequest("no file found"))){
+                case FilePart(_, _, _, result) =>
+                  Future.successful(Ok(result.toString))
+              }
+            }
+          val response = call(essentialAction, fakeRequest)
+          whenReady(response) { res =>
+            helper.mockDb should have size 0
+          }
+          status(response) shouldBe UNAUTHORIZED
+        }
+      }
+
+      "OAuth2.essentialAction" should "parse request body after authenticating" in {
+        val helper = new Helper()
+        forAll { testUser: User =>
+          val fakeRequest = FakeRequest("GET", "/").
+            withHeaders("Authorization" -> s"Bearer ${testUser.accessToken}").
+            withBody(helper.multipartFormData)
+
+          implicit val writable = helper.multiPartFormDataWritable(fakeRequest)
+
+          val essentialAction = oauth2withMockedServiceForEssentialAction(Right(testUser), testUser.accessToken).
+            essentialAction(BodyParsers.parse.multipartFormData(helper.handleFilePart)) { request =>
+              request.body.file("file").fold(Future.successful(BadRequest("no file found"))){
+                case FilePart(_, _, _, result) =>
+                  Future.successful(Ok(result.toString))
+              }
+            }
+          val response = call(essentialAction, fakeRequest)
+          whenReady(response) { res =>
+            helper.mockDb should have size 10
+          }
+          status(response) shouldBe OK
+        }
       }
   }
 }

--- a/tut/README.md
+++ b/tut/README.md
@@ -102,6 +102,26 @@ def heartbeat = OAuth2Action(isEmployee)(implicitly[ExecutionContext], implicitl
 }
 ```
 
+or use(recommended) [EssentialAction](https://www.playframework.com/documentation/2.5.x/ScalaEssentialAction) to authenticate request first and then proceed with everything else like request body parsing etc.
+side effects of not using EssentialAction is explained in detail in this [issue](https://github.com/zalando-incubator/hutmann/issues/8)
+
+```tut:silent
+import scala.concurrent.ExecutionContext
+import play.api.libs.ws.WSClient
+import play.api.Configuration
+import scala.util.Future
+
+//these come from the application normally
+implicit val ws: WSClient = null
+implicit val config: Configuration = null
+import scala.concurrent.ExecutionContext.Implicits.global
+
+def heartbeat = OAuth2Action()(implicitly[ExecutionContext], implicitly[WSClient], implicitly[Configuration]).essentialAction(parse.default) { 
+    Future.successful(Ok("<3"))
+}
+```
+
+
 will check if the token is from realm "/employees" and has a scope "uid" property set.
 
 In both cases, the body of the action will only get called when the user may access it, and error responses are generated accordingly. If you do not


### PR DESCRIPTION
Fix for [issue](https://github.com/zalando-incubator/hutmann/issues/8).

Bug is reproduced in [test case](https://github.com/sharma-rohit/hutmann/blob/issue-8/test/org/zalando/hutmann/authentication/OAuth2ActionTest.scala#L145)